### PR TITLE
Various improvements to linker script and startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ name = "atsama5d27"
 version = "0.1.0"
 dependencies = [
  "armv7",
+ "r0",
  "rtt-target",
  "utralib",
 ]
@@ -39,6 +40,12 @@ checksum = "b3d72d5477478f85bd00b6521780dfba1ec6cdaadcf90b8b181c36d7de561f9b"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "r0"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
 
 [[package]]
 name = "rtt-target"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,14 @@ edition = "2021"
 
 [dependencies]
 armv7 = { git = "https://github.com/Foundation-Devices/armv7.git", branch = "update" }
-rtt-target = { git = "https://github.com/Foundation-Devices/rtt-target.git", branch = "cortex-a", features = ["cortex-a"] }
+rtt-target = { git = "https://github.com/Foundation-Devices/rtt-target.git", branch = "cortex-a", features = ["cortex-a"], optional = true }
 utralib = { git = "https://github.com/Foundation-Devices/keyOS.git", branch = "main", default_features=false, features = ["atsama5d27"] }
+r0 = "1.0.0"
+
+[features]
+rtt = ["rtt-target"]
+
+default = []
 
 [profile.dev]
 #codegen-units = 1

--- a/link.ld
+++ b/link.ld
@@ -1,63 +1,65 @@
-/* This will be provided by the user (see `memory.x`) */
 INCLUDE memory.x
-ENTRY(start);
+ENTRY(reset);
 
 SECTIONS
 {
-  .text :
-  {
-    *(.text .text.*);
     . = ALIGN(4);
-    __etext = .;
-  } > SRAM
+	.text : {
+		_stext = .;
+		*(.text .text.*);
+		*(.rodata)                 /* read-only data (constants) */
+		*(.rodata*)
+		. = ALIGN(4);
+		*(.glue_7)
+		. = ALIGN(4);
+		*(.eh_frame)
+		. = ALIGN(4);
+ 		_etext = . ;
+	} > SRAM
 
-  .rodata __etext : ALIGN(4)
-  {
-    *(.rodata .rodata.*);
+	. = ALIGN(4);
+	.dummy : {
+		_edummy = .;
+	} > SRAM
+
+	.data : AT (LOADADDR(.dummy)) {
+		_sdata = .;
+		*(.vectors)
+		*(.data)
+		_edata = .;
+	} > SRAM
+
+	/* collect all uninitialized .bss sections */
+	.bss (NOLOAD) : {
+		. = ALIGN(4);
+		_sbss = .;
+		*(.bss)
+		_ebss = .;
+	} > SRAM
+
+    /* Place the heap right after `.uninit` */
     . = ALIGN(4);
-  } > SRAM
+    __sheap = .;
 
-  .data : ALIGN(4)
-  {
-    *(.data .data.*);
-    . = ALIGN(4);
-  } > SRAM
-
-  /* LMA of .data */
-  __sidata = LOADADDR(.data);
-
-  /* ### .bss */
-  .bss : ALIGN(4)
-  {
-    __sbss = .;
-    *(.bss .bss.*);
-    . = ALIGN(4);
-    __ebss = .;
-  } > SRAM
-
-  /* Initial, IRQ, and Abort stack */
-  . += 4096;
-  . = ALIGN(8);
-  _stack_start = .;
-
-  /* Place the heap right after `.uninit` */
-  . = ALIGN(4);
-  __sheap = .;
-
-  /* ## .got */
-  /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in
+    /* ## .got */
+    /* Dynamic relocations are unsupported. This section is only used to detect relocatable code in
      the input files and raise an error if relocatable code is found */
-  .got (NOLOAD) :
-  {
-    KEEP(*(.got .got.*));
-  }
+    .got (NOLOAD) :
+    {
+        KEEP(*(.got .got.*));
+    }
 
-  /* ## Discarded sections */
-  /DISCARD/ :
-  {
-    /* Unused exception related info that only wastes space */
-    *(.ARM.exidx);
-    *(.ARM.exidx.*);
-    *(.ARM.extab.*);
-  }
+    /* ## Discarded sections */
+    /DISCARD/ :
+    {
+        /* Unused exception related info that only wastes space */
+        *(.ARM.exidx);
+        *(.ARM.exidx.*);
+        *(.ARM.extab.*);
+    }
 }
+
+_romsize = _edata - _stext;
+_sramsize = _ebss - _stext;
+
+end = .;  /* define a global symbol marking the end of application */

--- a/memory.x
+++ b/memory.x
@@ -1,4 +1,8 @@
 MEMORY
 {
-  SRAM : ORIGIN = 0x23f00000, LENGTH = 10240K
+    /* The origin is shifted to accommodate the AT91Bootstrap bootloader */
+    SRAM : ORIGIN = 0x23f00000, LENGTH = 10240K
 }
+
+_top_of_memory = 0x210000; /* Top of memory */
+_sram_start = 0x200000;  /* Start of SRAM */

--- a/scripts/.gdbinit
+++ b/scripts/.gdbinit
@@ -1,2 +1,7 @@
+set pagination off
+
+tui new-layout mylayout {-horizontal src 1 asm 1} 2 status 0 cmd 1
+layout mylayout
+
 target remote :3333
 load

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -3,4 +3,4 @@
 set -e
 
 cargo build
-arm-none-eabi-gdb ../target/armv7a-none-eabi/debug/atsama5d27
+arm-none-eabi-gdb -q ../target/armv7a-none-eabi/debug/atsama5d27

--- a/scripts/write_bin_sdcard.sh
+++ b/scripts/write_bin_sdcard.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Configure to your sdcard path
+export VOLUME="/Volumes/NO NAME"
+
+cargo build
+arm-none-eabi-objcopy -I elf32-littlearm -O binary ../target/armv7a-none-eabi/debug/atsama5d27 "$VOLUME/app.bin"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
 
+pub mod pio;
 pub mod pmc;
 pub mod trng;

--- a/src/start.S
+++ b/src/start.S
@@ -1,12 +1,93 @@
-.section .text.start
-.global start
+.section start
+	.text
 
-start:
+	.globl reset
+	.align 4
 
-# Set the stack pointer
-ldr r0, =_stack_start
+reset:
+
+/* Exception vectors (should be a branch to be detected as a valid code by the rom */
+_exception_vectors:
+	b 	reset_vector    /* reset */
+	b 	undef_vector 	/* Undefined Instruction */
+	b 	swi_vector   	/* Software Interrupt */
+	b 	pabt_vector  	/* Prefetch Abort */
+	b 	dabt_vector  	/* Data Abort */
+.word		_romsize	/* Size of the binary for ROMCode loading */
+	b 	irq_vector	/* IRQ : read the AIC */
+	b 	fiq_vector      /* FIQ */
+
+undef_vector:
+	b 	undef_vector
+swi_vector:
+	b 	swi_vector
+pabt_vector:
+	b 	pabt_vector
+dabt_vector:
+	subs	pc, r14, #4	/* return */
+	nop
+rsvd_vector:
+	b 	rsvd_vector
+irq_vector:
+	b 	irq_vector
+fiq_vector:
+	b 	fiq_vector
+reset_vector:
+
+/*
+ * We must configure VBAR for the reset vectors to be at
+ * the start of SRAM (0x200000)
+ */
+mrc p15, 0, r2, c12, c0, 0 /* Read VBAR into R2 */
+ldr	r2, =_sram_start
+mcr	p15, 0, r2, c12, c0, 0
+
+/* Init the stack */
+_init_stack:
+
+ldr r0, =_top_of_memory
+
+# Set the stack for IRQ mode
+msr cpsr_c, #0xd2
 mov sp, r0
 
-# Run entrypoint
-BL _entry
-B .
+# Set the stack for FIQ mode
+msr cpsr_c, #0xd1
+mov sp, r0
+
+# Set the stack for Abort mode
+msr cpsr_c, #0xd7
+mov sp, r0
+
+# Set the stack for Undefined Instruction mode
+msr cpsr_c, #0xdb
+mov sp, r0
+
+# Back to Supervisor mode, (IRQ and FIQ both masked, Arm instruction
+# set) set the stack for Supervisor mode
+msr cpsr_c, #0xd3
+mov sp, r0
+
+/* Clear Abort condition if it is pending with help of the abort handler */
+ldr	r1, =(0x100)
+mrs	r0, cpsr
+eor	r0, r0, r1
+msr	cpsr_x, r0
+nop
+eor	r0, r0, r1
+msr	cpsr_x, r0
+
+/* Branch to the Rust _entry function */
+_branch_main:
+    BL _entry
+    B .
+
+.align
+_lp_data:
+        .word _edummy
+        .word _sdata
+        .word _edata
+
+_lp_bss:
+	.word _sbss
+	.word _ebss


### PR DESCRIPTION
This puts a proper vector table at the beginning of the binary and puts a reset handler at the entrypoint. Also handles `.bss` data section.

Mostly based on `AT91Bootstrap` with some bits from `r3` startup and linker files.

These changes allow a binary to be loaded by the `AT91Bootstrap` bootloader configured as an app loader.