### PR TITLE
Use round 0x20000000 as DRAM base address

### DIFF
--- a/memory.x
+++ b/memory.x
@@ -4,7 +4,7 @@ MEMORY
      * This address is within on-board DDR memory space.
      * DDR controller must be initialized by AT91Bootstrap before loading.
      */
-    DDR_MEM : ORIGIN = 0x23f00000, LENGTH = 10240K
+    DDR_MEM : ORIGIN = 0x20000000, LENGTH = 10240K
 }
 
 _top_of_memory = 0x210000; /* Top of SRAM memory */


### PR DESCRIPTION
This will require adjustment to the jump address in at91bootstrap config file.
Verified to work.