### PR TITLE
link.ld: fix .bss and .data collection

### DIFF
--- a/link.ld
+++ b/link.ld
@@ -27,6 +27,7 @@ SECTIONS
     _sdata = .;
     *(.vectors)
     *(.data)
+    *(.data.*)
     _edata = .;
   } > DDR_MEM
 
@@ -35,6 +36,7 @@ SECTIONS
     . = ALIGN(4);
     _sbss = .;
     *(.bss)
+    *(.bss.*)
     _ebss = .;
   } > DDR_MEM
 


### PR DESCRIPTION
Rust creates a new segment for each module (maybe even each variable), and they were not caaught, causing _ebss to be the same as _bss, making the bss zeroing pretty useless.